### PR TITLE
Fix root lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "lint": "pnpm -r eslint .",
+    "lint": "pnpm -r run lint",
     "test": "pnpm -r test",
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
-    "fmt": "pnpm -r prettier --write .",
+    "fmt": "pnpm exec prettier --write .",
     "db:start": "docker compose up -d dynamodb admin",
     "db:stop":  "docker compose down",
     "db:reset": "docker compose down --volumes && docker compose up -d dynamodb"


### PR DESCRIPTION
## Summary
- fix workspace lint and fmt scripts in the root package.json

## Testing
- `pnpm lint` *(fails: `@typescript-eslint/no-unsafe-return` etc.)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843a03d1e00832eac26bd360acefc21