### PR TITLE
Fix dev script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
+    "dev": "pnpm run start:dev",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { App } from 'supertest/types';
+import { Express } from 'express';
+import request from 'supertest';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: INestApplication<Express>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "lint": "pnpm -r eslint .",
+    "lint": "pnpm -r run lint",
     "test": "pnpm -r test",
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
-    "fmt": "pnpm -r prettier --write .",
+    "fmt": "pnpm exec prettier --write .",
     "db:start": "docker compose up -d dynamodb admin",
     "db:stop":  "docker compose down",
     "db:reset": "docker compose down --volumes && docker compose up -d dynamodb"


### PR DESCRIPTION
## Summary
- add a `dev` script to the backend package so `pnpm dev` starts both apps
- enforce ESLint rules in backend tests without disabling them

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6843a03d1e00832eac26bd360acefc21