### PR TITLE
Implement watchlist CRUD and optimistic UI

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,10 @@ import { SharedModule } from './shared/shared.module';
 import { HealthController } from './health/health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { WatchlistModule } from './watchlist/watchlist.module';
 
 @Module({
-  imports: [SharedModule, UsersModule, AuthModule],
+  imports: [SharedModule, UsersModule, AuthModule, WatchlistModule],
   controllers: [AppController, HealthController],
   providers: [AppService],
 })

--- a/backend/src/watchlist/watch.entity.ts
+++ b/backend/src/watchlist/watch.entity.ts
@@ -1,0 +1,5 @@
+export interface Watch {
+  uid: string;
+  code: string;
+  createdAt: string;
+}

--- a/backend/src/watchlist/watchlist.controller.ts
+++ b/backend/src/watchlist/watchlist.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { WatchlistService } from './watchlist.service';
+
+@Controller('users/:uid/watches')
+export class WatchlistController {
+  constructor(private readonly service: WatchlistService) {}
+
+  @Get()
+  async findAll(@Param('uid') uid: string) {
+    return this.service.findAll(uid);
+  }
+
+  @Post()
+  async create(@Param('uid') uid: string, @Body() body: { code: string }) {
+    return this.service.create(uid, body.code);
+  }
+
+  @Delete(':code')
+  async remove(@Param('uid') uid: string, @Param('code') code: string) {
+    await this.service.remove(uid, code);
+    return { ok: true };
+  }
+}

--- a/backend/src/watchlist/watchlist.module.ts
+++ b/backend/src/watchlist/watchlist.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WatchlistService } from './watchlist.service';
+import { WatchlistController } from './watchlist.controller';
+
+@Module({
+  providers: [WatchlistService],
+  controllers: [WatchlistController],
+  exports: [WatchlistService],
+})
+export class WatchlistModule {}

--- a/backend/src/watchlist/watchlist.service.spec.ts
+++ b/backend/src/watchlist/watchlist.service.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WatchlistService } from './watchlist.service';
+
+describe('WatchlistService', () => {
+  let service: WatchlistService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WatchlistService],
+    }).compile();
+
+    service = module.get<WatchlistService>(WatchlistService);
+  });
+
+  it('create and findAll should store watches', async () => {
+    const watch = await service.create('u1', '7203');
+    expect(watch.uid).toBe('u1');
+    expect(watch.code).toBe('7203');
+    expect(typeof watch.createdAt).toBe('string');
+
+    const list = await service.findAll('u1');
+    expect(list).toHaveLength(1);
+    expect(list[0].code).toBe('7203');
+  });
+
+  it('remove should delete watch', async () => {
+    await service.create('u1', '7203');
+    await service.create('u1', '1111');
+    await service.remove('u1', '7203');
+    const list = await service.findAll('u1');
+    expect(list.map((w) => w.code)).toEqual(['1111']);
+  });
+});

--- a/backend/src/watchlist/watchlist.service.ts
+++ b/backend/src/watchlist/watchlist.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { Watch } from './watch.entity';
+
+@Injectable()
+export class WatchlistService {
+  private data = new Map<string, Watch[]>();
+
+  /** 指定ユーザーのウォッチリスト取得 */
+  async findAll(uid: string): Promise<Watch[]> {
+    return Promise.resolve(this.data.get(uid) ?? []);
+  }
+
+  /** ウォッチ登録 */
+  async create(uid: string, code: string): Promise<Watch> {
+    const watch: Watch = { uid, code, createdAt: new Date().toISOString() };
+    const arr = this.data.get(uid) ?? [];
+    arr.push(watch);
+    this.data.set(uid, arr);
+    return Promise.resolve(watch);
+  }
+
+  /** 指定コードをウォッチから削除 */
+  async remove(uid: string, code: string): Promise<void> {
+    const arr = this.data.get(uid);
+    if (arr) {
+      this.data.set(
+        uid,
+        arr.filter((w) => w.code !== code),
+      );
+    }
+    return Promise.resolve();
+  }
+}

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -17,6 +17,8 @@
     "react-hook-form": "^7.56.2",
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.5.3",
+    "@tanstack/react-query": "^5.29.3",
+    "@tanstack/react-table": "^8.9.20",
     "zod": "^3.24.4",
     "zustand": "^5.0.4"
   },

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1,28 +1,35 @@
-import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { LoginPage } from './pages/LoginPage';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WatchlistPage } from './pages/WatchlistPage';
+import { LoginPage } from './pages/LoginPage';
 import { useAuth } from './store/auth';
+import React from 'react';
 
-const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const token = useAuth((s) => s.token);
   return token ? <>{children}</> : <Navigate to="/login" replace />;
 };
 
+const queryClient = new QueryClient();
+
 export const App: React.FC = () => (
-  <BrowserRouter>
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/app/*"
-        element={
-          <PrivateRoute>
-            <WatchlistPage />
-          </PrivateRoute>
-        }
-      />
-    </Routes>
-  </BrowserRouter>
+  <QueryClientProvider client={queryClient}>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/app/*"
+          element={
+            <PrivateRoute>
+              <WatchlistPage />
+            </PrivateRoute>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  </QueryClientProvider>
 );
 
 export default App;

--- a/frontend/app/src/pages/WatchlistPage.tsx
+++ b/frontend/app/src/pages/WatchlistPage.tsx
@@ -1,9 +1,118 @@
-import React from 'react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import React, { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useAuth } from '../store/auth';
 import toast from 'react-hot-toast';
+import jwtDecode from 'jwt-decode';
+
+interface Watch {
+  uid: string;
+  code: string;
+  createdAt: string;
+}
 
 export const WatchlistPage: React.FC = () => {
-  const { clearToken } = useAuth();
+  const { token, clearToken } = useAuth();
+  const uid = token ? (jwtDecode<{ sub: string }>(token).sub as string) : '';
+  const queryClient = useQueryClient();
+
+  const { data: watches = [] } = useQuery({
+    queryKey: ['watches', uid],
+    queryFn: async () => {
+      const res = await fetch(`/users/${uid}/watches`);
+      if (!res.ok) throw new Error('fetch failed');
+      return (await res.json()) as Watch[];
+    },
+  });
+
+  const addMutation = useMutation({
+    mutationFn: async (code: string) => {
+      const res = await fetch(`/users/${uid}/watches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error('add failed');
+      return (await res.json()) as Watch;
+    },
+    onMutate: async (code: string) => {
+      await queryClient.cancelQueries({ queryKey: ['watches', uid] });
+      const prev = queryClient.getQueryData<Watch[]>(['watches', uid]) ?? [];
+      queryClient.setQueryData(
+        ['watches', uid],
+        [...prev, { uid, code, createdAt: new Date().toISOString() }],
+      );
+      return { prev };
+    },
+    onError: (_err, _code, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(['watches', uid], ctx.prev);
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ['watches', uid] }),
+  });
+
+  const delMutation = useMutation({
+    mutationFn: async (code: string) => {
+      const res = await fetch(`/users/${uid}/watches/${code}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error('delete failed');
+    },
+    onMutate: async (code: string) => {
+      await queryClient.cancelQueries({ queryKey: ['watches', uid] });
+      const prev = queryClient.getQueryData<Watch[]>(['watches', uid]) ?? [];
+      queryClient.setQueryData(
+        ['watches', uid],
+        prev.filter((w) => w.code !== code),
+      );
+      return { prev };
+    },
+    onError: (_e, _code, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(['watches', uid], ctx.prev);
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ['watches', uid] }),
+  });
+
+  const columns = useMemo<ColumnDef<Watch>[]>(
+    () => [
+      { accessorKey: 'code', header: 'Code' },
+      { accessorKey: 'createdAt', header: 'Added' },
+      {
+        id: 'actions',
+        cell: ({ row }) => (
+          <button
+            className="text-red-500"
+            onClick={() => delMutation.mutate(row.original.code)}
+          >
+            Delete
+          </button>
+        ),
+      },
+    ],
+    [delMutation],
+  );
+
+  const table = useReactTable({
+    data: watches,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const [showAdd, setShowAdd] = useState(false);
+  const { register, handleSubmit, reset } = useForm<{ code: string }>();
+
+  const onSubmit = handleSubmit((data) => {
+    addMutation.mutate(data.code);
+    reset();
+    setShowAdd(false);
+  });
 
   const handleLogout = () => {
     clearToken();
@@ -12,35 +121,69 @@ export const WatchlistPage: React.FC = () => {
 
   return (
     <div className="max-w-3xl mx-auto mt-20 p-6 shadow rounded-lg">
-      <h2 className="text-2xl font-bold mb-4">📝 Watchlist（ダミー）</h2>
-      <button
-        onClick={handleLogout}
-        className="mb-4 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-      >
-        ログアウト
-      </button>
-      <table className="w-full table-auto border-collapse">
+      <div className="flex justify-between mb-4 items-center">
+        <h2 className="text-2xl font-bold">📝 Watchlist</h2>
+        <div>
+          <button
+            onClick={() => setShowAdd(true)}
+            className="mr-2 px-4 py-1 bg-blue-500 text-white rounded"
+          >
+            + Add
+          </button>
+          <button
+            onClick={handleLogout}
+            className="px-4 py-1 bg-red-500 text-white rounded"
+          >
+            Logout
+          </button>
+        </div>
+      </div>
+      <table className="w-full table-auto border-collapse mb-4">
         <thead>
-          <tr className="bg-gray-100">
-            <th className="border px-2 py-1 text-left">銘柄コード</th>
-            <th className="border px-2 py-1 text-left">銘柄名</th>
-            <th className="border px-2 py-1 text-left">最新価格</th>
-          </tr>
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id} className="bg-gray-100">
+              {hg.headers.map((h) => (
+                <th key={h.id} className="border px-2 py-1 text-left">
+                  {flexRender(h.column.columnDef.header, h.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
         </thead>
         <tbody>
-          <tr>
-            <td className="border px-2 py-1">7203</td>
-            <td className="border px-2 py-1">トヨタ自動車</td>
-            <td className="border px-2 py-1">¥2,000</td>
-          </tr>
-          <tr>
-            <td className="border px-2 py-1">9984</td>
-            <td className="border px-2 py-1">ソフトバンクグループ</td>
-            <td className="border px-2 py-1">¥8,000</td>
-          </tr>
-          {/* ここにさらにダミーデータを追加できます */}
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="border px-2 py-1">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
         </tbody>
       </table>
+      {showAdd && (
+        <form onSubmit={onSubmit} className="space-x-2">
+          <input
+            {...register('code')}
+            placeholder="code"
+            className="border px-2 py-1"
+          />
+          <button
+            type="submit"
+            className="px-3 py-1 bg-green-500 text-white rounded"
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowAdd(false)}
+            className="px-3 py-1 border rounded"
+          >
+            Cancel
+          </button>
+        </form>
+      )}
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.56.2(react@19.1.0))
+      '@tanstack/react-query':
+        specifier: ^5.29.3
+        version: 5.80.6(react@19.1.0)
+      '@tanstack/react-table':
+        specifier: ^8.9.20
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1384,6 +1390,25 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tanstack/query-core@5.80.6':
+    resolution: {integrity: sha512-nl7YxT/TAU+VTf+e2zTkObGTyY8YZBMnbgeA1ee66lIVqzKlYursAII6z5t0e6rXgwUMJSV4dshBTNacNpZHbQ==}
+
+  '@tanstack/react-query@5.80.6':
+    resolution: {integrity: sha512-izX+5CnkpON3NQGcEm3/d7LfFQNo9ZpFtX2QsINgCYK9LT2VCIdi8D3bMaMSNhrAJCznRoAkFic76uvLroALBw==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -5990,6 +6015,21 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/query-core@5.80.6': {}
+
+  '@tanstack/react-query@5.80.6(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.80.6
+      react: 19.1.0
+
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@tokenizer/inflate@0.2.7':
     dependencies:


### PR DESCRIPTION
## Summary
- add `Watch` entity and `WatchlistService`
- expose watchlist endpoints under `/users/:uid/watches`
- support watchlist CRUD in frontend using React Query and TanStack Table
- add watchlist unit tests and wire up module

## Testing
- `pnpm -r test`
- `pnpm --filter ./backend test:cov`
- `pnpm --filter ./backend lint`
- `pnpm --filter ./backend build`


------
https://chatgpt.com/codex/tasks/task_e_6843c67efe24832ebc43fef6a1bf5f3d