### PR TITLE
Implement watchlist CRUD and React UI

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,10 @@ import { SharedModule } from './shared/shared.module';
 import { HealthController } from './health/health.controller';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { WatchModule } from './watchlist/watch.module';
 
 @Module({
-  imports: [SharedModule, UsersModule, AuthModule],
+  imports: [SharedModule, UsersModule, AuthModule, WatchModule],
   controllers: [AppController, HealthController],
   providers: [AppService],
 })

--- a/backend/src/watchlist/watch.controller.ts
+++ b/backend/src/watchlist/watch.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import { WatchService } from './watch.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('users/:uid/watches')
+@UseGuards(JwtAuthGuard)
+export class WatchController {
+  constructor(private readonly service: WatchService) {}
+
+  @Get()
+  findAll(@Param('uid') uid: string) {
+    return this.service.findAll(uid);
+  }
+
+  @Post()
+  create(@Param('uid') uid: string, @Body() body: { code: string }) {
+    return this.service.create(uid, body.code);
+  }
+
+  @Delete()
+  remove(@Param('uid') uid: string, @Body() body: { code: string }) {
+    return this.service.remove(uid, body.code);
+  }
+}

--- a/backend/src/watchlist/watch.entity.ts
+++ b/backend/src/watchlist/watch.entity.ts
@@ -1,0 +1,5 @@
+export interface Watch {
+  uid: string;
+  code: string;
+  createdAt: string;
+}

--- a/backend/src/watchlist/watch.module.ts
+++ b/backend/src/watchlist/watch.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { WatchService } from './watch.service';
+import { WatchRepository } from './watch.repository';
+import { WatchController } from './watch.controller';
+
+@Module({
+  providers: [WatchService, WatchRepository],
+  controllers: [WatchController],
+  exports: [WatchService],
+})
+export class WatchModule {}

--- a/backend/src/watchlist/watch.repository.ts
+++ b/backend/src/watchlist/watch.repository.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { Watch } from './watch.entity';
+
+@Injectable()
+export class WatchRepository {
+  private store = new Map<string, Watch[]>();
+
+  findAll(uid: string): Promise<Watch[]> {
+    return Promise.resolve(this.store.get(uid) ?? []);
+  }
+
+  save(watch: Watch): Promise<void> {
+    const arr = this.store.get(watch.uid) ?? [];
+    arr.push(watch);
+    this.store.set(watch.uid, arr);
+    return Promise.resolve();
+  }
+
+  remove(uid: string, code: string): Promise<void> {
+    const arr = this.store.get(uid) ?? [];
+    this.store.set(
+      uid,
+      arr.filter((w) => w.code !== code),
+    );
+    return Promise.resolve();
+  }
+}

--- a/backend/src/watchlist/watch.service.spec.ts
+++ b/backend/src/watchlist/watch.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WatchService } from './watch.service';
+import { WatchRepository } from './watch.repository';
+
+describe('WatchService', () => {
+  let service: WatchService;
+  let repo: Partial<WatchRepository>;
+
+  beforeEach(async () => {
+    repo = {
+      findAll: jest.fn(),
+      save: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WatchService, { provide: WatchRepository, useValue: repo }],
+    }).compile();
+
+    service = module.get<WatchService>(WatchService);
+  });
+
+  it('findAll delegates to repository', async () => {
+    (repo.findAll as jest.Mock).mockResolvedValue(['x']);
+    await expect(service.findAll('u1')).resolves.toEqual(['x']);
+    expect(repo.findAll).toHaveBeenCalledWith('u1');
+  });
+
+  it('create builds watch and saves', async () => {
+    (repo.save as jest.Mock).mockResolvedValue(undefined);
+    const watch = await service.create('u2', '7203');
+    expect(watch.uid).toBe('u2');
+    expect(watch.code).toBe('7203');
+    expect(typeof watch.createdAt).toBe('string');
+    expect(repo.save).toHaveBeenCalledWith(watch);
+  });
+
+  it('remove delegates to repository', async () => {
+    (repo.remove as jest.Mock).mockResolvedValue(undefined);
+    await expect(service.remove('u1', '7203')).resolves.toBeUndefined();
+    expect(repo.remove).toHaveBeenCalledWith('u1', '7203');
+  });
+});

--- a/backend/src/watchlist/watch.service.ts
+++ b/backend/src/watchlist/watch.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { WatchRepository } from './watch.repository';
+import { Watch } from './watch.entity';
+
+@Injectable()
+export class WatchService {
+  constructor(private readonly repo: WatchRepository) {}
+
+  findAll(uid: string): Promise<Watch[]> {
+    return this.repo.findAll(uid);
+  }
+
+  async create(uid: string, code: string): Promise<Watch> {
+    const watch: Watch = { uid, code, createdAt: new Date().toISOString() };
+    await this.repo.save(watch);
+    return watch;
+  }
+
+  remove(uid: string, code: string): Promise<void> {
+    return this.repo.remove(uid, code);
+  }
+}

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -17,6 +17,8 @@
     "react-hook-form": "^7.56.2",
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.5.3",
+    "@tanstack/react-query": "^5.35.0",
+    "@tanstack/react-table": "^8.8.7",
     "zod": "^3.24.4",
     "zustand": "^5.0.4"
   },

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 
+const queryClient = new QueryClient()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/frontend/app/src/pages/WatchlistPage.tsx
+++ b/frontend/app/src/pages/WatchlistPage.tsx
@@ -1,46 +1,195 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../store/auth';
+import jwtDecode from 'jwt-decode';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+interface Watch {
+  uid: string;
+  code: string;
+  createdAt: string;
+}
 
 export const WatchlistPage: React.FC = () => {
-  const { clearToken } = useAuth();
+  const { clearToken, token } = useAuth();
+  const queryClient = useQueryClient();
+  const uid = token ? (jwtDecode<{ sub: string }>(token).sub) : '';
 
-  const handleLogout = () => {
-    clearToken();
-    toast('ログアウトしました');
+  const fetchWatches = async (): Promise<Watch[]> => {
+    const res = await fetch(`/users/${uid}/watches`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error('failed');
+    return res.json();
   };
 
+  const { data: watches = [] } = useQuery({
+    queryKey: ['watches', uid],
+    queryFn: fetchWatches,
+    enabled: !!uid,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: async (code: string) => {
+      const res = await fetch(`/users/${uid}/watches`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error();
+      return res.json() as Promise<Watch>;
+    },
+    onMutate: async (code) => {
+      await queryClient.cancelQueries({ queryKey: ['watches', uid] });
+      const prev = queryClient.getQueryData<Watch[]>(['watches', uid]) || [];
+      const optimistic: Watch = {
+        uid,
+        code,
+        createdAt: new Date().toISOString(),
+      };
+      queryClient.setQueryData(['watches', uid], [...prev, optimistic]);
+      return { prev };
+    },
+    onError: (_e, _c, ctx) => {
+      if (ctx) queryClient.setQueryData(['watches', uid], ctx.prev);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['watches', uid] }),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: async (code: string) => {
+      await fetch(`/users/${uid}/watches`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ code }),
+      });
+    },
+    onMutate: async (code) => {
+      await queryClient.cancelQueries({ queryKey: ['watches', uid] });
+      const prev = queryClient.getQueryData<Watch[]>(['watches', uid]) || [];
+      queryClient.setQueryData(
+        ['watches', uid],
+        prev.filter((w) => w.code !== code),
+      );
+      return { prev };
+    },
+    onError: (_e, _c, ctx) => {
+      if (ctx) queryClient.setQueryData(['watches', uid], ctx.prev);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['watches', uid] }),
+  });
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const { register, handleSubmit, reset } = useForm<{ code: string }>();
+
+  const onAdd = handleSubmit(async ({ code }) => {
+    await addMutation.mutateAsync(code);
+    toast.success('追加しました');
+    reset();
+    setModalOpen(false);
+  });
+
+  const columns: ColumnDef<Watch>[] = [
+    { accessorKey: 'code', header: '銘柄コード' },
+    { accessorKey: 'createdAt', header: '登録日' },
+    {
+      id: 'actions',
+      cell: ({ row }) => (
+        <button
+          className="text-blue-500"
+          onClick={() => removeMutation.mutate(row.original.code)}
+        >
+          削除
+        </button>
+      ),
+    },
+  ];
+
+  const table = useReactTable({
+    data: watches,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
   return (
-    <div className="max-w-3xl mx-auto mt-20 p-6 shadow rounded-lg">
-      <h2 className="text-2xl font-bold mb-4">📝 Watchlist（ダミー）</h2>
-      <button
-        onClick={handleLogout}
-        className="mb-4 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-      >
-        ログアウト
-      </button>
-      <table className="w-full table-auto border-collapse">
-        <thead>
-          <tr className="bg-gray-100">
-            <th className="border px-2 py-1 text-left">銘柄コード</th>
-            <th className="border px-2 py-1 text-left">銘柄名</th>
-            <th className="border px-2 py-1 text-left">最新価格</th>
-          </tr>
+    <div className="max-w-md mx-auto mt-10 p-6 shadow rounded-lg">
+      <h2 className="text-xl font-bold mb-4">Watchlist</h2>
+      <div className="mb-2 flex gap-2">
+        <button
+          onClick={() => setModalOpen(true)}
+          className="px-3 py-1 bg-blue-500 text-white rounded"
+        >
+          + Add
+        </button>
+        <button
+          onClick={clearToken}
+          className="px-3 py-1 bg-red-500 text-white rounded"
+        >
+          Logout
+        </button>
+      </div>
+      <table className="w-full table-auto border-collapse mb-4">
+        <thead className="bg-gray-100">
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id}>
+              {hg.headers.map((h) => (
+                <th key={h.id} className="border px-2 py-1 text-left">
+                  {flexRender(h.column.columnDef.header, h.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
         </thead>
         <tbody>
-          <tr>
-            <td className="border px-2 py-1">7203</td>
-            <td className="border px-2 py-1">トヨタ自動車</td>
-            <td className="border px-2 py-1">¥2,000</td>
-          </tr>
-          <tr>
-            <td className="border px-2 py-1">9984</td>
-            <td className="border px-2 py-1">ソフトバンクグループ</td>
-            <td className="border px-2 py-1">¥8,000</td>
-          </tr>
-          {/* ここにさらにダミーデータを追加できます */}
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="border px-2 py-1">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
         </tbody>
       </table>
+
+      {modalOpen && (
+        <form onSubmit={onAdd} className="space-y-2">
+          <input
+            className="border p-1 w-full"
+            placeholder="Code"
+            {...register('code')}
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="flex-1 bg-blue-500 text-white rounded px-3 py-1"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => setModalOpen(false)}
+              className="flex-1 bg-gray-300 rounded px-3 py-1"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add watchlist entity, repository, service and controller
- expose module in AppModule
- add unit tests for WatchService
- enable query client in React
- implement watchlist page with React Query, TanStack Table and modal add form
- add @tanstack/react-query and @tanstack/react-table dependencies

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684415731188832e861f969379bd157a