### PR TITLE
Remove obsolete compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   dynamodb:
     image: amazon/dynamodb-local:latest     # 公式イメージ【turn0search1】


### PR DESCRIPTION
## Summary
- remove deprecated version field from docker-compose.yml

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6845998c4c08832eaa0242fbc9102d42