### PR TITLE
Fix failing YahooSource test

### DIFF
--- a/backend/src/crawler/crawler.service.ts
+++ b/backend/src/crawler/crawler.service.ts
@@ -11,7 +11,7 @@ export class CrawlerService {
     let price: number | undefined;
     for (const src of this.sources) {
       try {
-        price = await src.getClose(code, date);
+        price = await src.getClose(code);
         break;
       } catch {
         // try next source

--- a/backend/src/price-sources/IPriceSource.ts
+++ b/backend/src/price-sources/IPriceSource.ts
@@ -1,4 +1,4 @@
 export interface IPriceSource {
   readonly name: string;
-  getClose(code: number, date: Date): Promise<number>;
+  getClose(code: number): Promise<number>;
 }

--- a/backend/src/tests/crawler.service.spec.ts
+++ b/backend/src/tests/crawler.service.spec.ts
@@ -13,7 +13,7 @@ describe('CrawlerService', () => {
     const svc = new CrawlerService([yahoo], repo as PriceRepository);
     const date = new Date('2023-01-01T00:00:00Z');
     await svc.fetchAndSave(7203, date);
-    expect(yahooGetClose).toHaveBeenCalled();
+    expect(yahooGetClose).toHaveBeenCalledWith(7203);
     expect(repo.put).toHaveBeenCalledWith(
       expect.objectContaining({ price: 2915 }),
     );

--- a/backend/src/tests/yahoo.source.spec.ts
+++ b/backend/src/tests/yahoo.source.spec.ts
@@ -3,9 +3,8 @@ import { YahooSource } from '../price-sources/yahoo.source';
 describe('YahooSource', () => {
   it('retrieves close price from Yahoo Finance', async () => {
     const src = new YahooSource();
-    const date = new Date('2023-01-04T00:00:00Z');
     try {
-      const price = await src.getClose(7203, date);
+      const price = await src.getClose(7203);
       expect(typeof price).toBe('number');
       expect(price).toBeGreaterThan(0);
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- align interface with YahooSource implementation
- adjust crawler service to use updated price source API
- update unit tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68459aad3924832e8a3c301045505441