### PR TITLE
Support DynamoDB local for crawler CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ store the closing price of a TSE code using the CLI:
 pnpm --filter backend run crawl 7203
 ```
 
+When running locally, set `DYNAMO_ENDPOINT=http://localhost:8000` in
+`backend/.env` so the CLI writes to DynamoDB Local.
+
 ## サンプルユーザー作成
 
 バックエンド起動後、以下のコマンドでログイン用のテストユーザーを登録できます。

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ JWT_SECRET= # JWT の署名キー
 JWT_EXPIRES_IN=1d # 有効期限
 AWS_REGION=ap-northeast-1
 DYNAMO_TABLE=Stocks
+DYNAMO_ENDPOINT=http://localhost:8000 # DynamoDB Local を使用する場合

--- a/backend/src/infra/repositories/price.repository.ts
+++ b/backend/src/infra/repositories/price.repository.ts
@@ -1,4 +1,5 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import type { DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
 
 export class PriceRepository {
@@ -6,7 +7,22 @@ export class PriceRepository {
   private readonly table = process.env.DYNAMO_TABLE ?? 'Stocks';
 
   constructor(client?: DynamoDBDocumentClient) {
-    this.client = client ?? DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    if (client) {
+      this.client = client;
+      return;
+    }
+
+    const config: DynamoDBClientConfig = {};
+    if (process.env.DYNAMO_ENDPOINT) {
+      config.endpoint = process.env.DYNAMO_ENDPOINT;
+      config.region = process.env.AWS_REGION ?? 'local';
+      config.credentials = {
+        accessKeyId: 'dummy',
+        secretAccessKey: 'dummy',
+      };
+    }
+
+    this.client = DynamoDBDocumentClient.from(new DynamoDBClient(config));
   }
 
   async put(item: Record<string, any>): Promise<void> {


### PR DESCRIPTION
## Summary
- allow the crawler's `PriceRepository` to connect to DynamoDB local when `DYNAMO_ENDPOINT` is provided
- document using DynamoDB local in the README
- add `DYNAMO_ENDPOINT` example in `.env.example`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68467d6f4580832e8f90c85a2d539659