### PR TITLE
Fix DynamoDB local persistence path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 1. pnpm install
-2. pnpm db:start   # DynamoDB Local
+2. pnpm db:start   # DynamoDB Local (creates ./dynamo_data)
 3. pnpm lint && pnpm test && pnpm dev
 ```
 
@@ -17,6 +17,9 @@ pnpm install
 pnpm db:start
 pnpm dev
 ```
+
+If the DynamoDB container fails with an SQLite error, ensure the `dynamo_data`
+folder exists and is writable (it is created automatically by `db:start`).
 
 The backend will be available on http://localhost:3000 and the frontend on http://localhost:5173.
 Stop DynamoDB with `pnpm db:stop` when finished.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
               "-sharedDb",                  # 1 つの DB ファイルを共有【turn0search2】
               "-dbPath", "/home/dynamodblocal/data"]
     volumes:
-      - dynamo_data:/home/dynamodblocal/data  # データ永続化【turn0search7】
+      - ./dynamo_data:/home/dynamodblocal/data  # データ永続化
 
   # 任意：ブラウザ UI が欲しい場合
   admin:
@@ -20,5 +20,3 @@ services:
     depends_on:
       - dynamodb
 
-volumes:
-  dynamo_data:

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
     "fmt": "pnpm exec prettier --write .",
-    "db:start": "docker compose up -d dynamodb admin",
+    "db:start": "mkdir -p dynamo_data && docker compose up -d dynamodb admin",
     "db:stop": "docker compose down",
-    "db:reset": "docker compose down --volumes && docker compose up -d dynamodb"
+    "db:reset": "rm -rf dynamo_data && docker compose down && docker compose up -d dynamodb"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- persist DynamoDB Local data under `./dynamo_data`
- warn in README about the `dynamo_data` folder
- ensure `db:start` creates the folder and update `db:reset`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6846d8b64938832eb415a5b1ebc6d99d