### PR TITLE
Add dev server startup test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "pnpm -r run lint",
-    "test": "pnpm -r test",
+    "test": "pnpm -r test && node scripts/check-dev.js",
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
     "fmt": "pnpm exec prettier --write .",

--- a/scripts/check-dev.js
+++ b/scripts/check-dev.js
@@ -1,0 +1,45 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function parseEnv(file) {
+  const env = {};
+  const content = fs.readFileSync(file, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [key, ...rest] = trimmed.split('=');
+    const value = rest.join('=');
+    env[key] = value.split('#')[0].trim() || 'test';
+  }
+  return env;
+}
+
+function runWithTimeout(cmd, env, timeoutMs) {
+  try {
+    return execSync(`timeout ${timeoutMs/1000}s bash -c '${cmd}'`, { env: { ...process.env, ...env }, encoding: 'utf8', stdio: 'pipe' });
+  } catch (err) {
+    // timeout exits with non-zero; still return captured output
+    return (err.stdout || '') + (err.stderr || '');
+  }
+}
+
+function checkBackend() {
+  const env = parseEnv(path.join(__dirname, '../backend/.env.example'));
+  const out = runWithTimeout('pnpm --filter ./backend run start:dev', env, 15000);
+  if (!/Nest application successfully started/.test(out)) throw new Error('backend dev failed');
+}
+
+function checkFrontend() {
+  const out = runWithTimeout('pnpm --filter ./frontend/app run dev', {}, 15000);
+  if (!/Local:/.test(out)) throw new Error('frontend dev failed');
+}
+
+try {
+  checkBackend();
+  checkFrontend();
+  console.log('dev servers started successfully');
+} catch (err) {
+  console.error(err.message || err);
+  process.exit(1);
+}

--- a/scripts/check-dev.js
+++ b/scripts/check-dev.js
@@ -53,7 +53,11 @@ function runAndCheck(cmd, env, pattern, timeoutMs) {
 
     child.on('exit', () => {
       clearTimeout(timer);
-      resolve(pattern.test(output));
+      const ok = pattern.test(output);
+      if (!ok) {
+        console.error(output);
+      }
+      resolve(ok);
     });
   });
 }
@@ -64,7 +68,7 @@ async function checkBackend() {
     'pnpm --filter ./backend run start:dev',
     env,
     /Nest application successfully started/,
-    15000,
+    30000,
   );
   if (!ok) throw new Error('backend dev failed');
 }
@@ -74,7 +78,7 @@ async function checkFrontend() {
     'pnpm --filter ./frontend/app run dev',
     {},
     /Local:/,
-    15000,
+    20000,
   );
   if (!ok) throw new Error('frontend dev failed');
 }


### PR DESCRIPTION
## Summary
- add a script `scripts/check-dev.js` that spins up backend and frontend dev servers briefly and checks they start
- run this script as part of `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f735f410832e83cc8aa11306d58e